### PR TITLE
Use `@typescript-eslint/naming-convention` instead of `camelcase`.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,102 @@
     }
   },
   "rules": {
-    "camelcase": ["error", { "allow": ["^_"] }],
+    "camelcase": "off",
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        "selector": "default",
+        "format": ["camelCase"]
+      },
+      // This and the next one allow properties like 'Content-Type'
+      {
+        "selector": "property",
+        "format": ["camelCase"],
+        "filter": {
+          "regex": "[- ]",
+          "match": false
+        }
+      },
+      {
+        "selector": "property",
+        "format": null,
+        "filter": {
+          "regex": "[- ]",
+          "match": true
+        },
+        "modifiers": ["requiresQuotes"]
+      },
+      // Allow functions to be imperativeLike or ComponentLike.
+      // Non-exported functions can have underscores, but public ones must not.
+      {
+        "selector": "function",
+        "modifiers": ["exported"],
+        "format": ["camelCase", "PascalCase"],
+        "leadingUnderscore": "forbid"
+      },
+      {
+        "selector": "function",
+        "format": ["camelCase", "PascalCase"],
+        "leadingUnderscore": "allow"
+      },
+      // Variables can be normalLike, CONSTANT_LIKE, or TypeLike.
+      {
+        "selector": "variable",
+        "format": ["camelCase", "UPPER_CASE", "PascalCase"]
+      },
+      // Some object literals like CSS variables and internal fields are prefixed with -- and __.
+      {
+        "selector": "objectLiteralProperty",
+        "format": null,
+        "filter": {
+          "regex": "^--|__",
+          "match": true
+        }
+      },
+      // Object literals can basically be anything depending on usage.
+      {
+        "selector": "objectLiteralProperty",
+        "format": ["camelCase", "UPPER_CASE", "PascalCase"]
+      },
+      {
+        "selector": "objectLiteralMethod",
+        "format": ["camelCase", "UPPER_CASE", "PascalCase"]
+      },
+      // Enums are always like Constants
+      {
+        "selector": "enumMember",
+        "format": ["PascalCase", "UPPER_CASE"]
+      },
+      // Unused variables should have a leading underscore, but destructured properties are fine to leave without.
+      {
+        "selector": "variable",
+        "format": ["camelCase"],
+        "modifiers": ["unused", "destructured"],
+        "leadingUnderscore": "allow"
+      },
+      {
+        "selector": "variable",
+        "format": ["camelCase"],
+        "modifiers": ["unused"],
+        "leadingUnderscore": "require"
+      },
+      {
+        "selector": "parameter",
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow"
+      },
+      // Private members _can_ have an underscore, but don't need it.
+      {
+        "selector": "memberLike",
+        "modifiers": ["private"],
+        "format": ["camelCase"],
+        "leadingUnderscore": "allow"
+      },
+      {
+        "selector": "typeLike",
+        "format": ["PascalCase"]
+      }
+    ],
     "no-labels": ["error", { "allowLoop": true }],
     // TypeScript-replaced rules
     "no-unused-vars": "off",

--- a/packages/api/src/HTTPUtils.tsx
+++ b/packages/api/src/HTTPUtils.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import queryString from "query-string";
 import snakecaseKeys from "snakecase-keys";
 

--- a/spyrothon_admin/src/modules/dashboards/DashboardSidebar.tsx
+++ b/spyrothon_admin/src/modules/dashboards/DashboardSidebar.tsx
@@ -32,23 +32,26 @@ export default function DashboardSidebar(props: DashboardSidebarProps) {
 
   return (
     <div className={classNames(styles.container, className)}>
-      {routes.map(({ id, path, label, icon: Icon, showLink = true }) =>
-        showLink ? (
-          <NavLink
-            exact
-            key={id}
-            className={styles.navItem}
-            route={path}
-            label={
-              <>
-                {Icon != null ? <Icon size={18} strokeWidth="2" style={ICON_STYLE} /> : null}
-                {label}
-              </>
-            }
-            fullwidth
-          />
-        ) : null,
-      )}
+      {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        routes.map(({ id, path, label, icon: Icon, showLink = true }) =>
+          showLink ? (
+            <NavLink
+              exact
+              key={id}
+              className={styles.navItem}
+              route={path}
+              label={
+                <>
+                  {Icon != null ? <Icon size={18} strokeWidth="2" style={ICON_STYLE} /> : null}
+                  {label}
+                </>
+              }
+              fullwidth
+            />
+          ) : null,
+        )
+      }
       <NavLink
         className={classNames(styles.navItem, styles.logout)}
         route={Routes.LOGOUT}

--- a/spyrothon_admin/src/modules/live/LiveRunTimers.tsx
+++ b/spyrothon_admin/src/modules/live/LiveRunTimers.tsx
@@ -56,6 +56,7 @@ function LiveTimer(props: LiveTimerProps) {
 }
 
 interface TimerAction {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   Icon: Icon;
   action: (dispatch: SafeDispatch) => void;
   disabled?: boolean;

--- a/spyrothon_graphics/src/uikit/svg/SVGLibrary.tsx
+++ b/spyrothon_graphics/src/uikit/svg/SVGLibrary.tsx
@@ -21,9 +21,12 @@ export const SVGFilters = {
 export default function SVGLibrary() {
   return (
     <svg style={{ display: "none" }}>
-      {Object.values(SVGFilters).map((Filter, index) => (
-        <Filter key={index} />
-      ))}
+      {Object.values(SVGFilters).map(
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        (Filter, index) => (
+          <Filter key={index} />
+        ),
+      )}
     </svg>
   );
 }


### PR DESCRIPTION
It's annoying, but needed for some new API typing things happening later