### PR TITLE
[api] make new User.Participant model and a migration script to duplicate data

### DIFF
--- a/spyrothon_api/lib/graphics_api/runs/participant.ex
+++ b/spyrothon_api/lib/graphics_api/runs/participant.ex
@@ -2,6 +2,8 @@ defmodule GraphicsAPI.Runs.Participant do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias GraphicsAPI.Users
+
   @fields [
     :id,
     :display_name,
@@ -10,6 +12,9 @@ defmodule GraphicsAPI.Runs.Participant do
     :pronouns,
     :has_webcam,
     :visible,
+
+    # Offloading data
+    :participant_id,
 
     # Run Fields
     :finished_at,
@@ -38,6 +43,8 @@ defmodule GraphicsAPI.Runs.Participant do
 
     field(:has_webcam, :boolean, default: false)
     field(:visible, :boolean, default: true)
+
+    belongs_to(:participant, Users.Participant)
 
     # Run Fields
     field(:actual_seconds, :integer)

--- a/spyrothon_api/lib/graphics_api/users.ex
+++ b/spyrothon_api/lib/graphics_api/users.ex
@@ -2,7 +2,7 @@ defmodule GraphicsAPI.Users do
   import Ecto.Query, warn: false
   alias GraphicsAPI.Repo
 
-  alias GraphicsAPI.Users.{Init, SessionToken, User}
+  alias GraphicsAPI.Users.{Init, SessionToken, User, Participant}
 
   @token_size 32
 
@@ -106,5 +106,34 @@ defmodule GraphicsAPI.Users do
     # Token expirations last ~1 month (60*60*24*30)
     DateTime.utc_now()
     |> DateTime.add(2_600_000, :second)
+  end
+
+  ###
+  # Participants
+  ###
+
+  def list_participants() do
+    Repo.all(Participant)
+  end
+
+  def get_participant(participant_id) do
+    Repo.get(Participant, participant_id)
+  end
+
+  def create_participant(params) do
+    %Participant{}
+    |> Participant.changeset(params)
+    |> Repo.insert()
+  end
+
+  def update_participant(participant = %Participant{}, params) do
+    participant
+    |> Participant.changeset(params)
+    |> Repo.update()
+  end
+
+  def delete_participant(participant = %Participant{}) do
+    participant
+    |> Repo.delete()
   end
 end

--- a/spyrothon_api/lib/graphics_api/users/participant.ex
+++ b/spyrothon_api/lib/graphics_api/users/participant.ex
@@ -1,0 +1,40 @@
+defmodule GraphicsAPI.Users.Participant do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @fields [
+    :user_id,
+    :display_name,
+    :twitch_name,
+    :twitter_name,
+    :pronouns,
+    :has_webcam
+  ]
+
+  @required_fields [
+    :display_name
+  ]
+
+  @derive {Jason.Encoder, only: @fields}
+  schema "users_participants" do
+    belongs_to(:user, GraphicsAPI.Users.User)
+
+    field(:display_name, :string)
+    field(:twitch_name, :string)
+    field(:twitter_name, :string)
+    field(:pronouns, :string)
+    field(:pronouns_visible, :boolean, default: true)
+
+    field(:has_webcam, :boolean, default: false)
+
+    timestamps()
+  end
+
+  def changeset(participant, params \\ %{}) do
+    participant
+    |> cast(params, @fields)
+    |> validate_required(@required_fields)
+  end
+
+  def fields, do: @fields
+end

--- a/spyrothon_api/priv/repo/migrations/20221030021637_make_participants_distinct.exs
+++ b/spyrothon_api/priv/repo/migrations/20221030021637_make_participants_distinct.exs
@@ -1,0 +1,19 @@
+defmodule GraphicsAPI.Repo.Migrations.MakeParticipantsDistinct do
+  use Ecto.Migration
+
+  def change do
+    create table(:users_participants) do
+      add(:user_id, references(:users_users))
+
+      # Display information
+      add(:display_name, :string)
+      add(:twitch_name, :string)
+      add(:twitter_name, :string)
+      add(:pronouns, :string)
+      add(:pronouns_visible, :boolean, default: true)
+      add(:has_webcam, :boolean, default: false)
+
+      timestamps()
+    end
+  end
+end

--- a/spyrothon_api/scripts/migrate_participants_to_table.exs
+++ b/spyrothon_api/scripts/migrate_participants_to_table.exs
@@ -1,0 +1,52 @@
+# This script moves participant data from the embedded `participant` schema
+# shared between runs and interviews into a dedicated table that will allow
+# the data to be reused across runs and events.
+#
+# Unshared data like run timing and interview scores are _not_ part of this
+# table and will still use an embedded schema to track them, since they are
+# tied directly to the usage of the participant with that subject.
+
+alias GraphicsAPI.Users
+alias GraphicsAPI.Runs.{Interview, Run, Participant}
+
+alias GraphicsAPI.Runs
+
+defmodule Migration do
+  def create_user_participant(run_participant) do
+    Map.from_struct(run_participant)
+    |> Map.put(:pronouns_visible, true)
+    |> Users.create_participant()
+  end
+
+  def map_participants_to_user_participants(participants) do
+    participants
+    |> Enum.map(fn p ->
+      {:ok, new_participant} = create_user_participant(p)
+
+      %Participant{p | participant_id: new_participant.id}
+      |> Map.from_struct()
+    end)
+  end
+
+  def create_participants_for_run(run = %Run{}) do
+    Runs.update_run(run, %{
+      runners: map_participants_to_user_participants(run.runners),
+      commentators: map_participants_to_user_participants(run.commentators)
+    })
+  end
+
+  def create_participants_for_interview(interview = %Interview{}) do
+    Runs.update_run(interview, %{
+      interviewers: map_participants_to_user_participants(interview.interviewers),
+      interviewees: map_participants_to_user_participants(interview.interviewees)
+    })
+  end
+end
+
+Runs.list_runs()
+|> Stream.each(&Migration.create_participants_for_run/1)
+|> Stream.run()
+
+Runs.list_interviews()
+|> Stream.each(&Migration.create_participants_for_interview/1)
+|> Stream.run()


### PR DESCRIPTION
This duplicates data from the current `Run.Participant` embedded schema into a dedicated table so that the information can be reused across runs and events.

It does not change how the information is currently loaded or delete any other data, it just duplicates it with the script.